### PR TITLE
Setting default for interval correctly

### DIFF
--- a/src/bgzfiltra/main.py
+++ b/src/bgzfiltra/main.py
@@ -133,7 +133,7 @@ def main(options):
                 db.insert_assigned(product, email, len(bugs), timestamp)
 
         # default for the interval is 24h
-        interval_minutes = int(options.get("<minutes>", 1440))
+        interval_minutes = int(options.get("<minutes>") or 1440)
         print("Waiting for {} minutes.".format(interval_minutes))
         time.sleep(60 * interval_minutes)
 


### PR DESCRIPTION
I'm not sure why the default in the .get() gets ignored, but this notation also provides a default of 1440 minutes if nothing is passed as an argument and the value therefore is None.

Fixes #1